### PR TITLE
Add dependencies to berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,6 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'apt', '~> 3.0.0'
+cookbook 'homebrew', '~> 2.1.0'

--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,5 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'apt', '~> 3.0.0'
-cookbook 'homebrew', '~> 2.1.0'
+cookbook 'apt'
+cookbook 'homebrew'

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,3 @@
 source 'https://supermarket.chef.io'
 
 metadata
-
-cookbook 'apt'
-cookbook 'homebrew'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,8 +13,8 @@ supports 'windows'
 supports 'ubuntu'
 supports 'debian'
 
-depends 'apt', '3.0.0'
-depends 'homebrew', '2.1.0'
+depends 'apt', '~> 3.0'
+depends 'homebrew', '~> 2.1'
 
 source_url 'https://github.com/mohitsethi/chef-atom'
 issues_url 'https://github.com/mohitsethi/chef-atom/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,8 +13,8 @@ supports 'windows'
 supports 'ubuntu'
 supports 'debian'
 
-depends 'apt'
-depends 'homebrew'
+depends 'apt', '3.0.0'
+depends 'homebrew', '2.1.0'
 
 source_url 'https://github.com/mohitsethi/chef-atom'
 issues_url 'https://github.com/mohitsethi/chef-atom/issues'


### PR DESCRIPTION
To ensure that Berkshelf pulls down the required cookbooks, I think they need to be added to the Berksfile. Which version should be required may be up for debate, but I just pulled the latest ones and put a pessimistic restriction on them.