### PR TITLE
Add mac_os_x_server to supports list

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ version '0.2.0'
 recipe 'atom::default', 'Installs/Configures Atom'
 
 supports 'mac_os_x'
+supports 'mac_os_x_server'
 supports 'windows'
 supports 'ubuntu'
 supports 'debian'


### PR DESCRIPTION
I'm not sure how many people are going to be using OSX Server and atom, but I figured it doesn't hurt adding it, since it is technically a different platform than `mac_os_x` in chef's eyes, and it does naturally have support.